### PR TITLE
Throw exception when recaptcha.validate throw an exception

### DIFF
--- a/src/Recaptcha/index.js
+++ b/src/Recaptcha/index.js
@@ -10,6 +10,7 @@
  */
 
 const ReCAPTCHA = require('recaptcha2')
+const GE = require('@adonisjs/generic-exceptions')
 const defaultConfig = require('../../config/recaptcha.js')
 
 class Recaptcha {
@@ -22,9 +23,7 @@ class Recaptcha {
     try {
       await recaptcha.validate(recaptchaResponse)
     } catch (errors) {
-      response
-        .status(400)
-        .send(recaptcha.translateErrors(errors || 'invalid-input-response'))
+      throw new GE.HttpException(recaptcha.translateErrors(errors || 'invalid-input-response'), 400, 'E_CAPTCHA')
     }
     await next()
   }

--- a/test/recaptcha.spec.js
+++ b/test/recaptcha.spec.js
@@ -50,9 +50,12 @@ test.group('Recaptcha', () => {
       }
     }
 
-    await recaptcha.handle({ response, request }, function () {})
-    assert.equal(400, response.code)
-    assert.equal('The response parameter is missing.', response.body)
+    try {
+      await recaptcha.handle({ response, request }, function () {})
+    } catch (e) {
+      assert.equal(400, e.status)
+      assert.equal('E_CAPTCHA: The response parameter is missing.', e.message)
+    }
   })
 
   test('get request error when recaptcha is invalid', async (assert) => {
@@ -81,9 +84,11 @@ test.group('Recaptcha', () => {
         return this.inputs[name]
       }
     }
-
-    await recaptcha.handle({ response, request }, function () {})
-    assert.equal(400, response.code)
-    assert.equal('The response parameter is invalid or malformed.', response.body)
+    try {
+      await recaptcha.handle({ response, request }, function () {})
+    } catch (e) {
+      assert.equal(400, e.status)
+      assert.equal('E_CAPTCHA: The response parameter is invalid or malformed.', e.message)
+    }
   })
 })


### PR DESCRIPTION
Currently when the recaptcha is wrong, the controller code is executed, with this throw the controller code won't be executed.